### PR TITLE
Declare app.js to concat first in gulp file

### DIFF
--- a/app/templates/_gulpfile.js
+++ b/app/templates/_gulpfile.js
@@ -3,7 +3,7 @@ var plugins = require("gulp-load-plugins")({lazy:false});
 
 gulp.task('scripts', function(){
     //combine all js files of the app
-    gulp.src(['!./app/**/*_test.js','./app/**/*.js'])
+    gulp.src(['!./app/**/*_test.js','./app/app.js','./app/**/*.js'])
         .pipe(plugins.jshint())
         .pipe(plugins.jshint.reporter('default'))
         .pipe(plugins.concat('app.js'))


### PR DESCRIPTION
/app.js is typically where the Angular app module is initially defined, and since other scripts may rely on that module, it needs to be included first in the concat javascript file.  

I accomplished this by explicitly defining it in the gulp file, before the wildcard javascripts.
